### PR TITLE
Fix unit tests

### DIFF
--- a/test/ZyRabbit.Enrichers.Polly.Tests/Services/ChannelFactoryTests.cs
+++ b/test/ZyRabbit.Enrichers.Polly.Tests/Services/ChannelFactoryTests.cs
@@ -24,7 +24,7 @@ namespace ZyRabbit.Enrichers.Polly.Tests.Services
 				.Returns(connection.Object);
 			connectionFactory
 				.SetupSequence(c => c.CreateConnection(
-						It.IsAny<List<string>>()
+						It.IsAny<List<string>>(), It.IsAny<string>()
 					))
 				.Throws(new BrokerUnreachableException(new Exception()))
 				.Throws(new BrokerUnreachableException(new Exception()))
@@ -50,7 +50,7 @@ namespace ZyRabbit.Enrichers.Polly.Tests.Services
 		}
 
 		[Fact]
-		public async Task Should_Use_Create_Channel_Policy_When_Creaing_Channels()
+		public async Task Should_Use_Create_Channel_Policy_When_Creating_Channels()
 		{
 			/* Setup */
 			var channel = new Mock<IModel>();
@@ -61,7 +61,7 @@ namespace ZyRabbit.Enrichers.Polly.Tests.Services
 				.Returns(connection.Object);
 			connectionFactory
 				.Setup(c => c.CreateConnection(
-					It.IsAny<List<string>>()
+					It.IsAny<List<string>>(), It.IsAny<string>()
 				))
 				.Returns(connection.Object);
 			connection

--- a/test/ZyRabbit.Tests/Channel/ChannelFactoryTests.cs
+++ b/test/ZyRabbit.Tests/Channel/ChannelFactoryTests.cs
@@ -16,11 +16,11 @@ namespace ZyRabbit.Tests.Channel
 		public async Task Should_Throw_Exception_If_Connection_Is_Closed_By_Application()
 		{
 			/* Setup */
-			var connectionFactroy = new Mock<IConnectionFactory>();
+			var connectionFactory = new Mock<IConnectionFactory>();
 			var connection = new Mock<IConnection>();
-			connectionFactroy
+			connectionFactory
 				.Setup(c => c.CreateConnection(
-					It.IsAny<List<string>>()))
+					It.IsAny<List<string>>(), It.IsAny<string>()))
 				.Returns(connection.Object);
 			connection
 				.Setup(c => c.IsOpen)
@@ -28,7 +28,7 @@ namespace ZyRabbit.Tests.Channel
 			connection
 				.Setup(c => c.CloseReason)
 				.Returns(new ShutdownEventArgs(ShutdownInitiator.Application, 0, string.Empty));
-			var channelFactory = new ChannelFactory(connectionFactroy.Object, ZyRabbitConfiguration.Local);
+			var channelFactory = new ChannelFactory(connectionFactory.Object, ZyRabbitConfiguration.Local);
 
 			/* Test */
 			/* Assert */
@@ -47,11 +47,11 @@ namespace ZyRabbit.Tests.Channel
 		public async Task Should_Throw_Exception_If_Connection_Is_Closed_By_Lib_But_Is_Not_Recoverable()
 		{
 			/* Setup */
-			var connectionFactroy = new Mock<IConnectionFactory>();
+			var connectionFactory = new Mock<IConnectionFactory>();
 			var connection = new Mock<IConnection>();
-			connectionFactroy
+			connectionFactory
 				.Setup(c => c.CreateConnection(
-					It.IsAny<List<string>>()))
+					It.IsAny<List<string>>(), It.IsAny<string>()))
 				.Returns(connection.Object);
 			connection
 				.Setup(c => c.IsOpen)
@@ -59,7 +59,7 @@ namespace ZyRabbit.Tests.Channel
 			connection
 				.Setup(c => c.CloseReason)
 				.Returns(new ShutdownEventArgs(ShutdownInitiator.Library, 0, string.Empty));
-			var channelFactory = new ChannelFactory(connectionFactroy.Object, ZyRabbitConfiguration.Local);
+			var channelFactory = new ChannelFactory(connectionFactory.Object, ZyRabbitConfiguration.Local);
 
 			/* Test */
 			/* Assert */
@@ -79,11 +79,11 @@ namespace ZyRabbit.Tests.Channel
 		{
 			/* Setup */
 			var channel = new Mock<IModel>();
-			var connectionFactroy = new Mock<IConnectionFactory>();
+			var connectionFactory = new Mock<IConnectionFactory>();
 			var connection = new Mock<IConnection>();
-			connectionFactroy
+			connectionFactory
 				.Setup(c => c.CreateConnection(
-					It.IsAny<List<string>>()))
+					It.IsAny<List<string>>(), It.IsAny<string>()))
 				.Returns(connection.Object);
 			connection
 				.Setup(c => c.CreateModel())
@@ -91,7 +91,7 @@ namespace ZyRabbit.Tests.Channel
 			connection
 				.Setup(c => c.IsOpen)
 				.Returns(true);
-			var channelFactory = new ChannelFactory(connectionFactroy.Object, ZyRabbitConfiguration.Local);
+			var channelFactory = new ChannelFactory(connectionFactory.Object, ZyRabbitConfiguration.Local);
 
 			/* Test */
 			var retrievedChannel = await channelFactory.CreateChannelAsync();
@@ -110,7 +110,7 @@ namespace ZyRabbit.Tests.Channel
 			var recoverable = connection.As<IRecoverable>();
 			connectionFactroy
 				.Setup(c => c.CreateConnection(
-					It.IsAny<List<string>>()))
+					It.IsAny<List<string>>(), It.IsAny<string>()))
 				.Returns(connection.Object);
 			connection
 				.Setup(c => c.CreateModel())

--- a/test/ZyRabbit.Tests/Common/ConnectionStringParserTests.cs
+++ b/test/ZyRabbit.Tests/Common/ConnectionStringParserTests.cs
@@ -83,10 +83,10 @@ namespace ZyRabbit.Tests.Common
 			Assert.Equal(expected: TimeSpan.FromSeconds(10), actual: config.RequestTimeout);
 			Assert.Equal(expected: TimeSpan.FromSeconds(20), actual: config.PublishConfirmTimeout);
 			Assert.Equal(expected: TimeSpan.FromSeconds(30), actual: config.RecoveryInterval);
-			Assert.Equal(expected: false, actual: config.AutoCloseConnection);
-			Assert.Equal(expected: false, actual: config.PersistentDeliveryMode);
-			Assert.Equal(expected: false, actual: config.AutomaticRecovery);
-			Assert.Equal(expected: false, actual: config.TopologyRecovery);
+			Assert.False(config.AutoCloseConnection);
+			Assert.False(config.PersistentDeliveryMode);
+			Assert.False(config.AutomaticRecovery);
+			Assert.False(config.TopologyRecovery);
 		}
 
 		[Fact]
@@ -204,10 +204,10 @@ namespace ZyRabbit.Tests.Common
 			Assert.Equal(expected: TimeSpan.FromSeconds(10), actual: config.RequestTimeout);
 			Assert.Equal(expected: TimeSpan.FromSeconds(20), actual: config.PublishConfirmTimeout);
 			Assert.Equal(expected: TimeSpan.FromSeconds(30), actual: config.RecoveryInterval);
-			Assert.Equal(expected: false, actual: config.AutoCloseConnection);
-			Assert.Equal(expected: false, actual: config.PersistentDeliveryMode);
-			Assert.Equal(expected: false, actual: config.AutomaticRecovery);
-			Assert.Equal(expected: false, actual: config.TopologyRecovery);
+			Assert.False(config.AutoCloseConnection);
+			Assert.False(config.PersistentDeliveryMode);
+			Assert.False(config.AutomaticRecovery);
+			Assert.False(config.TopologyRecovery);
 		}
 
 		[Fact]
@@ -236,10 +236,10 @@ namespace ZyRabbit.Tests.Common
 			Assert.Equal(expected: TimeSpan.FromSeconds(10), actual: config.RequestTimeout);
 			Assert.Equal(expected: TimeSpan.FromSeconds(20), actual: config.PublishConfirmTimeout);
 			Assert.Equal(expected: TimeSpan.FromSeconds(30), actual: config.RecoveryInterval);
-			Assert.Equal(expected: false, actual: config.AutoCloseConnection);
-			Assert.Equal(expected: false, actual: config.PersistentDeliveryMode);
-			Assert.Equal(expected: false, actual: config.AutomaticRecovery);
-			Assert.Equal(expected: false, actual: config.TopologyRecovery);
+			Assert.False(config.AutoCloseConnection);
+			Assert.False(config.PersistentDeliveryMode);
+			Assert.False(config.AutomaticRecovery);
+			Assert.False(config.TopologyRecovery);
 		}
 
 		[Fact]
@@ -268,10 +268,10 @@ namespace ZyRabbit.Tests.Common
 			Assert.Equal(expected: TimeSpan.FromSeconds(10), actual: config.RequestTimeout);
 			Assert.Equal(expected: TimeSpan.FromSeconds(20), actual: config.PublishConfirmTimeout);
 			Assert.Equal(expected: TimeSpan.FromSeconds(30), actual: config.RecoveryInterval);
-			Assert.Equal(expected: false, actual: config.AutoCloseConnection);
-			Assert.Equal(expected: false, actual: config.PersistentDeliveryMode);
-			Assert.Equal(expected: false, actual: config.AutomaticRecovery);
-			Assert.Equal(expected: false, actual: config.TopologyRecovery);
+			Assert.False(config.AutoCloseConnection);
+			Assert.False(config.PersistentDeliveryMode);
+			Assert.False(config.AutomaticRecovery);
+			Assert.False(config.TopologyRecovery);
 		}
 
 		[Fact]
@@ -300,10 +300,10 @@ namespace ZyRabbit.Tests.Common
 			Assert.Equal(expected: TimeSpan.FromSeconds(10), actual: config.RequestTimeout);
 			Assert.Equal(expected: TimeSpan.FromSeconds(20), actual: config.PublishConfirmTimeout);
 			Assert.Equal(expected: TimeSpan.FromSeconds(30), actual: config.RecoveryInterval);
-			Assert.Equal(expected: false, actual: config.AutoCloseConnection);
-			Assert.Equal(expected: false, actual: config.PersistentDeliveryMode);
-			Assert.Equal(expected: false, actual: config.AutomaticRecovery);
-			Assert.Equal(expected: false, actual: config.TopologyRecovery);
+			Assert.False(config.AutoCloseConnection);
+			Assert.False(config.PersistentDeliveryMode);
+			Assert.False(config.AutomaticRecovery);
+			Assert.False(config.TopologyRecovery);
 		}
 
 		[Fact]
@@ -325,7 +325,7 @@ namespace ZyRabbit.Tests.Common
 
 			/* Assert */
 			Assert.NotNull(exception);
-			Assert.IsType(typeof(FormatException), exception);
+			Assert.IsType<FormatException>(exception);
 			Assert.Equal(expected: "The supplied port 'port' in the connection string is not a number", actual: exception.Message);
 		}
 
@@ -348,7 +348,7 @@ namespace ZyRabbit.Tests.Common
 
 			/* Assert */
 			Assert.NotNull(exception);
-			Assert.IsType(typeof(ArgumentException), exception);
+			Assert.IsType<ArgumentException>(exception);
 			Assert.Equal(expected: "No configuration property named 'badproperty'", actual: exception.Message);
 		}
 


### PR DESCRIPTION
### Description

This PR is intended to fix failed unit tests, in order to do the following has been done:
- 'StaticChannelPool' class does not swallow 'ChannelAvailabilityException' exception anymore
- Mock for correct overload of "CreateConnection" method is used in tests
- Fix some warning regarding to misusage of XUnit assertions

### Check List
- [x] All test passed.
- [x] Pull Request to `master` branch.
